### PR TITLE
Fix image and remove citations from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,8 @@ This is a companion training guide for BioDIGS, a GDSCN project that brings a re
 
 The GDSCN (Genomics Data Science Community Network) is a consortium of educators who aim to create a world where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research. You can find more information about its mission and initiatives [here](https://www.gdscn.org/home).
 
-```{r echo=FALSE, fig.alt="BioDIGS logo", out.width='300px', fig.align='center'}
-knitr::include_graphics("https://raw.githubusercontent.com/fhdsl/GDSCN_BioDIGS_Book/main/assets/GDSCN_style/logo_BioDIGS_final.png")
-```
+<img src="https://raw.githubusercontent.com/fhdsl/GDSCN_BioDIGS_Book/main/assets/GDSCN_style/logo_BioDIGS_final.png"/>
 
-One critical aspect of an undergraduate STEM education is hands-on research. Undergraduate research experiences enhance what students learn in the classroom as well as increase a student's interest in pursuing STEM careers [@Russell2007]. It can also lead to improved scientific reasoning and increased academic performance overall [@Buffalari2020]. However, many students at underresourced institutions like community colleges, Historically Black Colleges and Universities (HBCUs), tribal colleges and universities, and Hispanic-serving institutions have limited access to research opportunities compared to their cohorts at larger four-year colleges and R1 institutions. These students are also more likely to belong to groups that are already under-represented in STEM disciplines, particularly genomics and data science [@Canner2017; @GDSCN2022].
-
-The BioDIGS Project aims to be at the intersection of genomics, data science, cloud computing, and education.
 
 ## Target Audience
 


### PR DESCRIPTION
Addresses issue #30 

This PR fixes the image syntax (changes it from Rmd to md) and also removes the paragraph with citations, as that part seemed a bit too long for a short README overview.